### PR TITLE
Use sizeof() instead of hard-coded buffer sizes

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -79,7 +79,7 @@ void audio_load_sfx()
 	if (init_failed) return;
 
 	for (i = 0; i < NUM_SFX; i++) {
-		snprintf(path, 530, "%s%s.wav", config->assets_dir, data_sfx_files[i]);
+		snprintf(path, sizeof(path), "%s%s.wav", config->assets_dir, data_sfx_files[i]);
 		sfx[i] = LoadSound(path);
 	}
 }
@@ -100,12 +100,12 @@ void audio_play_bgm(int id)
 	unload_bgm();
 
 	//Try to load the BGM track in OGG format
-	snprintf(path, 530, "%s%s.ogg", config->assets_dir, data_bgm_files[id]);
+	snprintf(path, sizeof(path), "%s%s.ogg", config->assets_dir, data_bgm_files[id]);
 	bgm = LoadMusicStream(path);
 
 	if (!IsMusicReady(bgm)) {
 		//Try to load the BGM track in XM format
-		snprintf(path, 530, "%s%s.xm", config->assets_dir, data_bgm_files[id]);
+		snprintf(path, sizeof(path), "%s%s.xm", config->assets_dir, data_bgm_files[id]);
 		bgm = LoadMusicStream(path);
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -97,7 +97,7 @@ bool str_starts_with(const char* str, const char* start);
 bool str_only_whitespaces(const char* str);
 int get_file_size(const char* path);
 const char* file_from_path(const char* path);
-void process_path(const char* in, char* out, int maxlen);
+void process_path(const char* in, char* out, size_t maxlen);
 bool readable_dir(const char* path);
 bool create_parent_dirs(const char* path);
 void msgbox_error(const char* msg);
@@ -908,7 +908,7 @@ static void start_level(int level_num, int difficulty, bool skip_initial_sequenc
 		case DIFFICULTY_SUPER:  diffch = 's'; break;
 	}
 
-	snprintf(filename, 530, "%slevel%d%c", config.assets_dir, level_num, diffch);
+	snprintf(filename, sizeof(filename), "%slevel%d%c", config.assets_dir, level_num, diffch);
 
 	renderer_show_save_error(false);
 	play_clear();
@@ -1004,7 +1004,7 @@ static bool find_assets_dir()
 	if (cli.assets_dir != NULL) { //Directory set from CLI
 		int len;
 
-		process_path(cli.assets_dir, config.assets_dir, 512);
+		process_path(cli.assets_dir, config.assets_dir, sizeof(config.assets_dir));
 		len = strlen(cli.assets_dir);
 
 		if (len <= 510) {
@@ -1020,19 +1020,19 @@ static bool find_assets_dir()
 		char base_path[480];
 		char path[512];
 
-		process_path(GetApplicationDirectory(), base_path, 480);
+		process_path(GetApplicationDirectory(), base_path, sizeof(base_path));
 
-		snprintf(path, 512, "%s/%s", base_path, "assets/");
+		snprintf(path, sizeof(path), "%s/%s", base_path, "assets/");
 		if (readable_dir(path)) {
-			snprintf(config.assets_dir, 512, "%s", path);
+			snprintf(config.assets_dir, sizeof(config.assets_dir), "%s", path);
 
 			return true;
 		}
 
 #ifndef _WIN32
-		snprintf(path, 512, "%s/%s", base_path, "../share/games/alexvsbus/");
+		snprintf(path, sizeof(path), "%s/%s", base_path, "../share/games/alexvsbus/");
 		if (readable_dir(path)) {
-			snprintf(config.assets_dir, 512, "%s", path);
+			snprintf(config.assets_dir, sizeof(config.assets_dir), "%s", path);
 
 			return true;
 		}
@@ -1051,25 +1051,25 @@ static void find_config_path()
 	char tmp[512];
 
 	if (cli.config != NULL) {
-		snprintf(tmp, 512, "%s", cli.config);
+		snprintf(tmp, sizeof(tmp), "%s", cli.config);
 	} else {
 #if defined(_WIN32)
-		snprintf(tmp, 512, "%s/alexvsbus/alexvsbus.cfg", getenv("APPDATA"));
+		snprintf(tmp, sizeof(tmp), "%s/alexvsbus/alexvsbus.cfg", getenv("APPDATA"));
 #elif defined(__APPLE__)
-		snprintf(tmp, 512,
+		snprintf(tmp, sizeof(tmp),
 			"%s/Library/Preferences/alexvsbus/alexvsbus.cfg", getenv("HOME"));
 #else
 		const char* xdg_config = getenv("XDG_CONFIG_HOME");
 
 		if (xdg_config == NULL) {
-			snprintf(tmp, 512, "%s/.config/alexvsbus/alexvsbus.cfg", getenv("HOME"));
+			snprintf(tmp, sizeof(tmp), "%s/.config/alexvsbus/alexvsbus.cfg", getenv("HOME"));
 		} else {
-			snprintf(tmp, 512, "%s/alexvsbus/alexvsbus.cfg", xdg_config);
+			snprintf(tmp, sizeof(tmp), "%s/alexvsbus/alexvsbus.cfg", xdg_config);
 		}
 #endif
 	}
 
-	process_path(tmp, config_path, 512);
+	process_path(tmp, config_path, sizeof(config_path));
 #endif //__ANDROID__
 }
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -164,7 +164,7 @@ bool renderer_load_gfx()
 	int comp;
 	int format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
 
-	snprintf(filename, 530, "%sgfx.png", config->assets_dir);
+	snprintf(filename, sizeof(filename), "%sgfx.png", config->assets_dir);
 
 	file_data = LoadFileData(filename, &file_size);
 	if (file_data == NULL) {

--- a/src/util.c
+++ b/src/util.c
@@ -111,10 +111,10 @@ const char* file_from_path(const char* path)
 //1. If running on Windows, replaces backslashes (\) with forward slashes (/)
 //2. Removes consecutive slashes
 //3. Removes the slash at the end if present
-void process_path(const char* in, char* out, int maxlen)
+void process_path(const char* in, char* out, size_t maxlen)
 {
-	int outlen = 0;
-	int i = 0;
+	size_t outlen = 0;
+	size_t i = 0;
 
 	while (in[i] != '\0') {
 		bool is_slash = (in[i] == '/');


### PR DESCRIPTION
This PR makes all calls to `snprintf()` and `process_path()` use the `sizeof()` operator to determine the target buffer size, instead of hard-coding the values.