### PR TITLE
fix: the handlerawinput function processes windows r... in...

### DIFF
--- a/raylib/platforms/rcore_desktop_win32.c
+++ b/raylib/platforms/rcore_desktop_win32.c
@@ -1258,7 +1258,7 @@ void OpenURL(const char *url)
     else
     {
         char *cmd = (char *)RL_CALLOC(strlen(url) + 32, sizeof(char));
-        sprintf(cmd, "explorer \"%s\"", url);
+        snprintf(cmd, strlen(url) + 32, "explorer \"%s\"", url);
         int result = system(cmd);
         if (result == -1) TRACELOG(LOG_WARNING, "OpenURL() child process could not be created");
         RL_FREE(cmd);
@@ -2053,8 +2053,9 @@ static void HandleMouseButton(int button, char state)
 static void HandleRawInput(LPARAM lparam)
 {
     RAWINPUT input = { 0 };
-
-    UINT inputSize = sizeof(input);
+    UINT inputSize = 0;
+    if (GetRawInputData((HRAWINPUT)lparam, RID_INPUT, NULL, &inputSize, sizeof(RAWINPUTHEADER)) != 0) return;
+    if (inputSize > sizeof(input)) return;
     UINT size = GetRawInputData((HRAWINPUT)lparam, RID_INPUT, &input, &inputSize, sizeof(RAWINPUTHEADER));
 
     if (size == (UINT)-1) TRACELOG(LOG_ERROR, "WIN32: Failed to get raw input data [ERROR: %lu]", GetLastError());


### PR DESCRIPTION
## Summary
Fix high severity security issue in `raylib/platforms/rcore_desktop_win32.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `raylib/platforms/rcore_desktop_win32.c:793` |

**Description**: The HandleRawInput function processes Windows raw input messages. If it uses a fixed-size stack buffer to receive raw input data via GetRawInputData without first querying the required size and dynamically allocating an appropriately sized buffer, a crafted raw input message with a payload larger than the fixed buffer will overflow the stack. Stack overflows can overwrite the return address and enable arbitrary code execution.

## Changes
- `raylib/platforms/rcore_desktop_win32.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
